### PR TITLE
Adjust script to use several profile data sources

### DIFF
--- a/02_init/rollout.sh
+++ b/02_init/rollout.sh
@@ -34,6 +34,22 @@ set_segment_bashrc()
 			else
 				count=$(ssh $ext_host "grep greenplum_path ~/.bashrc" 2> /dev/null | wc -l)
 				if [ "$count" -eq "0" ]; then
+				  # if GREENPLUM_PATH is not defined, will populate it
+				  if [ -z "$GREENPLUM_PATH" ]; then
+            # we have several files to store profile data depend on version and distribution
+            for profile_filename in ~/.bashrc ~/.profile ~/.bash_profile
+            do
+              if [ -f "$profile_filename" ]; then
+                # we want to extract GREENPLUM_PATH from the line like
+                # source /usr/lib/gpdb/greenplum_path.sh
+                greenplum_path_line=$(grep -v "^#" "$profile_filename" | grep "greenplum_path" || :)
+                if [ -n "$greenplum_path_line" ]; then
+                  GREENPLUM_PATH=$(echo "$greenplum_path_line" | awk '{print $2}')
+                  break
+                fi
+              fi
+            done
+          fi
 					echo "Adding greenplum_path to $ext_host .bashrc"
 					ssh $ext_host "echo \"source $GREENPLUM_PATH\" >> ~/.bashrc"
 				fi

--- a/04_load/start_gpfdist.sh
+++ b/04_load/start_gpfdist.sh
@@ -5,6 +5,15 @@ PWD=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 GPFDIST_PORT=$1
 GEN_DATA_PATH=$2
 
+# to use gpfdist we should source additional variables
+for profile_filename in ~/.bashrc ~/.profile ~/.bash_profile
+do
+		if [ -f "$profile_filename" ]; then
+			# don't fail if an error is happening in the admin's profile
+			source "$profile_filename" || true
+		fi
+done
+
 gpfdist -p $GPFDIST_PORT -d $GEN_DATA_PATH > gpfdist.$GPFDIST_PORT.log 2>&1 < gpfdist.$GPFDIST_PORT.log &
 pid=$!
 

--- a/functions.sh
+++ b/functions.sh
@@ -35,11 +35,16 @@ get_gpfdist_port()
 
 source_bashrc()
 {
-	if [ -f ~/.bashrc ]; then
-		# don't fail if an error is happening in the admin's profile
-		source ~/.bashrc || true
-	fi
-	count=$(grep -v "^#" ~/.bashrc | grep "greenplum_path" | wc -l)
+	count=0
+	# we have several files to store profile data depend on version and distribution
+	for profile_filename in ~/.bashrc ~/.profile ~/.bash_profile
+	do
+		if [ -f "$profile_filename" ]; then
+			# don't fail if an error is happening in the admin's profile
+			source "$profile_filename" || true
+			count=$((count+$(grep -v "^#" "$profile_filename" | grep "greenplum_path" | wc -l)))
+		fi
+	done
 	if [ "$count" -eq "0" ]; then
 		get_version
 		if [[ "$VERSION" == *"gpdb"* ]]; then


### PR DESCRIPTION
With novel ADB profile data stored inside of ~/.profile or ~/.bash_profile. Let's use them as well.