### PR TITLE
Changed `integer` to `bigint` to handle larger scale.

### DIFF
--- a/03_ddl/023.gpdb.web_returns.sql
+++ b/03_ddl/023.gpdb.web_returns.sql
@@ -12,7 +12,7 @@ CREATE TABLE tpcds.web_returns (
     wr_returning_addr_sk integer,
     wr_web_page_sk integer,
     wr_reason_sk integer,
-    wr_order_number integer NOT NULL,
+    wr_order_number bigint NOT NULL,
     wr_return_quantity integer,
     wr_return_amt numeric(7,2),
     wr_return_tax numeric(7,2),

--- a/03_ddl/024.gpdb.web_sales.sql
+++ b/03_ddl/024.gpdb.web_sales.sql
@@ -16,7 +16,7 @@ CREATE TABLE tpcds.web_sales (
     ws_ship_mode_sk integer,
     ws_warehouse_sk integer,
     ws_promo_sk integer,
-    ws_order_number integer NOT NULL,
+    ws_order_number bigint NOT NULL,
     ws_quantity integer,
     ws_wholesale_cost numeric(7,2),
     ws_list_price numeric(7,2),


### PR DESCRIPTION
For larger tests (50TB and up), data load will fail due to out of range numbers.

This is done on loading of `web_sales`, and `web_returns`.

cherry picked from commit https://github.com/pivotal/TPC-DS/commit/49ad911c90c026421c5b63077fbcf7644a915783